### PR TITLE
honor case-sensitive columns from ps

### DIFF
--- a/models/lesson.go
+++ b/models/lesson.go
@@ -283,11 +283,21 @@ func GetCompletedLessonsForUser(uid string) (*[]LessonsComplete, error) {
 
 func GetOverallWPMAndAccuracy(uid string) (*map[string]interface{}, error) {
 	stats := make(map[string]interface{})
+  aliases := map[string]string{
+      "avgaccuracy": "avgAccuracy",
+      "avgwpm": "avgWPM",
+    }
 
 	err := db.QueryRowx(
-		`select AVG(accuracy) as avgAccuracy, AVG(wpm) as avgWPM 
+		`select AVG(accuracy) as avgaccuracy, AVG(wpm) as avgwpm 
 		from lessonscompleted 
 		where uid=$1`, uid).MapScan(stats)
+
+  // UI expects case-sensitive keys
+  for k, v := range aliases {
+    stats[v] = stats[k]
+    delete(stats, k)
+  }
 
 	// In the case of a new User
 	if stats["avgAccuracy"] == nil || stats["avgWPM"] == nil {


### PR DESCRIPTION
resolves [#29](https://github.com/codephil-columbia/typephil/issues/29)

PS returns rows with case-insensitive columns, but frontend expected case-sensitive columns; thus defaulted to `avgWPM=0`, `avgAccuracy=0`.